### PR TITLE
Exclude start and exit nodes from graph

### DIFF
--- a/js-cfg/build.gradle.kts
+++ b/js-cfg/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("jvm") version "1.9.0"
+    application
 }
 
 group = "me.vldf"
@@ -21,4 +22,8 @@ tasks.test {
 
 kotlin {
     jvmToolchain(17)
+}
+
+application {
+    mainClass = "MainKt"
 }

--- a/js-cfg/example.js
+++ b/js-cfg/example.js
@@ -1,0 +1,18 @@
+function hello() {
+    if (a == 10) {
+        console.log("124");
+    }
+
+     for (i in abc) {
+        if (b == 20) {
+            console.log("whatever");
+        } else {
+            return;
+        }
+     }
+
+     while (b < 10) {
+         b -= 1;
+         console.log("hello");
+     }
+}

--- a/js-cfg/src/main/kotlin/Main.kt
+++ b/js-cfg/src/main/kotlin/Main.kt
@@ -1,0 +1,7 @@
+import kotlin.io.path.Path
+import kotlin.io.path.readText
+
+fun main() {
+    val source = Path("js-cfg/example.js").readText()
+    println(JsCfgEntrypoint.buildCfg(source))
+}

--- a/js-cfg/src/main/kotlin/cfg/nodes/statements/blocks/StatementsBlock.kt
+++ b/js-cfg/src/main/kotlin/cfg/nodes/statements/blocks/StatementsBlock.kt
@@ -16,10 +16,10 @@ class StatementsBlock(
     val conditionalSuccessors: MutableMap<ConditionType, StatementsBlock> = mutableMapOf()
 
     val allSuccessors: Set<StatementsBlock>
-        get() = successors + conditionalSuccessors.values + backSuccessors
+        get() = findNormalSuccessors() + findNormalConditionalSuccessors().values + findNormalBackSuccessors()
 
     val allForwardSuccessors: Set<StatementsBlock>
-        get() = successors + conditionalSuccessors.values
+        get() = findNormalSuccessors() + findNormalConditionalSuccessors().values
 
     fun getExitBlocks(): List<StatementsBlock> {
         if (this.isExit && this.successors.isEmpty() && conditionalSuccessors.isEmpty()) {
@@ -34,3 +34,38 @@ sealed class ConditionType
 
 data object ElseConditionType : ConditionType()
 data class ExpressionConditionType(val expression: Expression) : ConditionType()
+
+fun StatementsBlock.findNormalSuccessors(): Set<StatementsBlock> {
+    val normalSuccessors = mutableSetOf<StatementsBlock>()
+    for (successor in successors) {
+        if (successor.isEntry || successor.isExit) {
+            normalSuccessors.addAll(successor.findNormalSuccessors())
+        } else {
+            normalSuccessors.add(successor)
+        }
+    }
+    return normalSuccessors
+}
+
+fun StatementsBlock.findNormalConditionalSuccessors(): Map<ConditionType, StatementsBlock> {
+    val normalSuccessors = mutableMapOf<ConditionType, StatementsBlock>()
+    for ((type, successor) in conditionalSuccessors) {
+        val normalSuccessor = successor.findNormalSuccessors().firstOrNull()
+        if (normalSuccessor != null) {
+            normalSuccessors[type] = normalSuccessor
+        }
+    }
+    return normalSuccessors
+}
+
+fun StatementsBlock.findNormalBackSuccessors(): Set<StatementsBlock> {
+    val normalSuccessors = mutableSetOf<StatementsBlock>()
+    for (successor in backSuccessors) {
+        if (successor.isEntry || successor.isExit) {
+            normalSuccessors.addAll(successor.findNormalBackSuccessors())
+        } else {
+            normalSuccessors.add(successor)
+        }
+    }
+    return normalSuccessors
+}


### PR DESCRIPTION
I did edit the representation and added methods to find nearest non-special nodes. It's not clean nor efficient solution, but a simple one.

Loops don't work now, investigating the problem